### PR TITLE
refactor: centralize PrismaClient instance management

### DIFF
--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -4,8 +4,7 @@ import bcrypt from 'bcrypt'
 import * as z from 'zod'
 import jwt from 'jsonwebtoken'
 import { loginSchema } from '../../lib/validations/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 // Login input validation schema
 

--- a/api/auth/register.ts
+++ b/api/auth/register.ts
@@ -4,8 +4,7 @@ import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcrypt'
 import * as z from 'zod'
 import { registerSchema } from '../../lib/validations/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 
 // Compare this snippet from ChoreBattleAPI/api/auth/login.ts:

--- a/api/choreFrequencies/create.ts
+++ b/api/choreFrequencies/create.ts
@@ -3,8 +3,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node'
 import { PrismaClient, Prisma } from '@prisma/client'
 import { frequencySchema } from '../../lib/validations/choreFrequencies'
 import { withAuth } from '../middleware/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function createFrequency(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body

--- a/api/choreFrequencies/delete.ts
+++ b/api/choreFrequencies/delete.ts
@@ -2,8 +2,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 import { PrismaClient, Prisma } from '@prisma/client'
 import { frequencySchema } from '../../lib/validations/choreFrequencies'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function updateFrequency(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body

--- a/api/choreFrequencies/get.ts
+++ b/api/choreFrequencies/get.ts
@@ -2,8 +2,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 import { PrismaClient } from '@prisma/client'
 import { withAuth } from '../middleware/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function getFrequencies(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body

--- a/api/choreFrequencies/update.ts
+++ b/api/choreFrequencies/update.ts
@@ -3,8 +3,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node'
 import { PrismaClient, Prisma } from '@prisma/client'
 import { frequencySchema } from '../../lib/validations/choreFrequencies'
 import { withAuth } from '../middleware/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function updateFrequency(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body

--- a/api/chores/create.ts
+++ b/api/chores/create.ts
@@ -4,8 +4,7 @@ import { PrismaClient, Prisma } from '@prisma/client'
 import { withAuth } from '../middleware/auth'
 import { choreSchema } from '../../lib/validations/chores'
 import { calculateNextReset } from '../../lib/utils/chores'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function handler(req: VercelRequest, res: VercelResponse) {
     if (req.method !== 'POST') {

--- a/api/chores/delete.ts
+++ b/api/chores/delete.ts
@@ -2,8 +2,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 import { PrismaClient, Prisma } from '@prisma/client'
 import { withAuth } from '../middleware/auth'
-
-const prisma = new PrismaClient()
+import prisma from '../../lib/prisma'
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'DELETE') {

--- a/api/chores/get.ts
+++ b/api/chores/get.ts
@@ -4,8 +4,8 @@ import { PrismaClient } from '@prisma/client'
 import { withAuth } from '../middleware/auth'
 import { ChoreWithRelations, ChoreResponse } from '../../lib/types/chores'
 import { isChoreExpired, getChoreResetData } from '../../lib/utils/chores'
+import prisma from '../../lib/prisma'
 
-const prisma = new PrismaClient()
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {

--- a/api/chores/update.ts
+++ b/api/chores/update.ts
@@ -1,11 +1,10 @@
 // api/chores/update.ts
 import { VercelRequest, VercelResponse } from '@vercel/node'
-import { PrismaClient, Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import { withAuth } from '../middleware/auth'
 import { choreUpdateSchema } from '../../lib/validations/chores'
 import { calculateNextReset } from '../../lib/utils/chores'
-
-const prisma = new PrismaClient()
+import prisma from "../../lib/prisma"
 
 async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'PATCH' && req.method !== 'PUT') {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+// lib/prisma.ts
+import { PrismaClient } from '@prisma/client'
+
+// Prevent multiple instances in development due to hot reloading
+declare global {
+  var prisma: PrismaClient | undefined
+}
+
+const prisma = global.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma
+
+export default prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vercel/node": "^5.1.2",
         "bcrypt": "^5.1.1",
         "jsonwebtoken": "^9.0.2",
+        "nanoid": "^5.1.2",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -2638,6 +2639,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
+      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vercel/node": "^5.1.2",
     "bcrypt": "^5.1.1",
     "jsonwebtoken": "^9.0.2",
+    "nanoid": "^5.1.2",
     "zod": "^3.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Move PrismaClient instantiation to a separate file to prevent  multiple instances during development. Update all relevant  API files to import the centralized instance. Add nanoid  dependency for unique ID generation in future features.