### PR TITLE
feat(api): add leaderboard and update claim functionality

### DIFF
--- a/api/chores/complete.ts
+++ b/api/chores/complete.ts
@@ -1,0 +1,146 @@
+// api/chores/complete.ts
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
+import { choreCompletionSchema } from '../../lib/validations/choreCompletions'
+import { calculateNextReset } from '../../lib/utils/chores'
+
+async function completeChore(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { decodedUser } = req.body
+  const { id } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to complete chores' })
+  }
+
+  try {
+    // Validate input
+    const validatedData = choreCompletionSchema.parse(req.body)
+
+    // Get the chore and verify access
+    const chore = await prisma.chore.findFirst({
+      where: {
+        id: id as string,
+        householdId: decodedUser.householdId
+      },
+      include: {
+        rank: true,
+        frequency: true,
+        completions: {
+          orderBy: { completedAt: 'desc' },
+          take: 1
+        }
+      }
+    })
+
+    if (!chore) {
+      return res.status(404).json({ error: 'Chore not found or not accessible' })
+    }
+
+    if (chore.isComplete) {
+      return res.status(400).json({ error: 'Chore is already completed' })
+    }
+
+    // Calculate streak
+    let newStreak = 1
+    if (chore.completions.length > 0) {
+      const lastCompletion = chore.completions[0]
+      const daysSinceLastCompletion = Math.floor(
+        (new Date().getTime() - lastCompletion.completedAt.getTime()) / (1000 * 60 * 60 * 24)
+      )
+      if (daysSinceLastCompletion <= chore.frequency.daysInterval) {
+        newStreak = chore.currentStreak + 1
+      }
+    }
+
+    // Calculate points (including streak bonus)
+    const streakBonus = Math.floor(newStreak / 5) * 5 // 5 bonus points for every 5 days in streak
+    const totalPoints = chore.rank.pointValue + streakBonus
+
+    // Update everything in a transaction
+    const result = await prisma.$transaction(async (tx) => {
+      // Create completion record
+      const completion = await tx.choreCompletion.create({
+        data: {
+          choreId: chore.id,
+          userId: decodedUser.userId,
+          householdId: decodedUser.householdId,
+          pointsEarned: totalPoints,
+          streakCount: newStreak,
+          note: validatedData.note,
+          photoUrl: validatedData.photoUrl
+        }
+      })
+
+      // Create point history
+      const pointHistory = await tx.pointHistory.create({
+        data: {
+          points: totalPoints,
+          type: 'CHORE_COMPLETE',
+          reason: `Completed Chore: ${chore.title} (Streak: ${newStreak})`,
+          userId: decodedUser.userId,
+          householdId: decodedUser.householdId,
+          choreId: chore.id
+        }
+      })
+
+      // Update user's total points
+      const user = await tx.user.update({
+        where: { id: decodedUser.userId },
+        data: {
+          totalPoints: { increment: totalPoints }
+        }
+      })
+
+      // Update chore
+      const updatedChore = await tx.chore.update({
+        where: { id: chore.id },
+        data: {
+          isComplete: true,
+          currentStreak: newStreak,
+          longestStreak: Math.max(newStreak, chore.longestStreak),
+          totalCompletions: { increment: 1 },
+          lastCompletedBy: decodedUser.userId,
+          nextReset: calculateNextReset(new Date(), chore.frequency)
+        },
+        include: {
+          rank: true,
+          frequency: true,
+          assignedTo: {
+            select: {
+              id: true,
+              name: true
+            }
+          },
+          createdBy: {
+            select: {
+              id: true,
+              name: true
+            }
+          }
+        }
+      })
+
+      return {
+        completion,
+        pointHistory,
+        chore: updatedChore,
+        pointsEarned: totalPoints
+      }
+    })
+
+    return res.status(200).json({
+      message: 'Chore completed successfully',
+      ...result
+    })
+  } catch (error) {
+    console.error('Error completing chore:', error)
+    return res.status(500).json({ error: 'Failed to complete chore' })
+  }
+}
+
+export default withAuth(completeChore) 

--- a/api/chores/index.ts
+++ b/api/chores/index.ts
@@ -6,10 +6,17 @@ import createChore from './create'
 import updateChore from './update'
 import deleteChore from './delete'
 import getChoresById from './getById'
+import completeChore from './complete'
 
 async function handler(req: VercelRequest, res: VercelResponse) {
-  const {id} = req.query
-  console.log('id', id)
+  const { id, action } = req.query
+
+  // Handle specific actions
+  if (action === 'complete' && id) {
+    return completeChore(req, res)
+  }
+
+  // Handle standard CRUD operations
   switch (req.method) {
     case 'GET':
       if (id) {
@@ -27,4 +34,4 @@ async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-export default handler;
+export default withAuth(handler)

--- a/api/points/create.ts
+++ b/api/points/create.ts
@@ -1,0 +1,69 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import * as z from 'zod'
+import { withAuth } from '../../lib/middleware/auth'
+
+const createPointSchema = z.object({
+  points: z.number(),
+  reason: z.string(),
+  userId: z.string(),
+  type: z.enum(['CHORE_COMPLETE', 'REWARD_CLAIMED', 'BONUS'])
+})
+
+async function createPointHistory(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to manage points' })
+  }
+
+  try {
+    const validatedData = createPointSchema.parse(req.body)
+
+    // Verify the target user belongs to the same household
+    const targetUser = await prisma.user.findFirst({
+      where: {
+        id: validatedData.userId,
+        householdId: decodedUser.householdId
+      }
+    })
+
+    if (!targetUser) {
+      return res.status(404).json({ error: 'Target user not found or not in same household' })
+    }
+
+    // Create point history and update user's total points in a transaction
+    const pointHistory = await prisma.$transaction(async (tx) => {
+      const history = await tx.pointHistory.create({
+        data: {
+          points: validatedData.points,
+          reason: validatedData.reason,
+          type: validatedData.type,
+          userId: validatedData.userId,
+          householdId: decodedUser.householdId
+        }
+      })
+
+      await tx.user.update({
+        where: { id: validatedData.userId },
+        data: {
+          totalPoints: {
+            increment: validatedData.points
+          }
+        }
+      })
+
+      return history
+    })
+
+    return res.status(201).json({ pointHistory })
+  } catch (error) {
+    console.error('Error creating point history:', error)
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'Invalid input', details: error.issues })
+    }
+    return res.status(500).json({ error: 'Failed to create point history' })
+  }
+}
+
+export default withAuth(createPointHistory) 

--- a/api/points/get.ts
+++ b/api/points/get.ts
@@ -1,5 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
 
 async function getPointHistory(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body
@@ -62,4 +63,4 @@ async function getPointHistory(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-export default getPointHistory 
+export default withAuth(getPointHistory) 

--- a/api/points/getChore.ts
+++ b/api/points/getChore.ts
@@ -1,5 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
 
 async function getChorePointHistory(req: VercelRequest, res: VercelResponse) {
   const { decodedUser } = req.body
@@ -70,4 +71,4 @@ async function getChorePointHistory(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-export default getChorePointHistory 
+export default withAuth(getChorePointHistory) 

--- a/api/points/leaderboard.ts
+++ b/api/points/leaderboard.ts
@@ -1,0 +1,69 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
+
+async function getLeaderboard(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { timeframe = 'all' } = req.query // 'all', 'week', 'month'
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to view leaderboard' })
+  }
+
+  try {
+    let dateFilter = {}
+    const now = new Date()
+    
+    if (timeframe === 'week') {
+      const weekAgo = new Date(now.setDate(now.getDate() - 7))
+      dateFilter = { createdAt: { gte: weekAgo } }
+    } else if (timeframe === 'month') {
+      const monthAgo = new Date(now.setMonth(now.getMonth() - 1))
+      dateFilter = { createdAt: { gte: monthAgo } }
+    }
+
+    const leaderboard = await prisma.user.findMany({
+      where: {
+        householdId: decodedUser.householdId
+      },
+      select: {
+        id: true,
+        name: true,
+        totalPoints: true,
+        _count: {
+          select: {
+            ChoreCompletion: true
+          }
+        },
+        pointHistory: {
+          where: dateFilter,
+          select: {
+            points: true
+          }
+        }
+      },
+      orderBy: {
+        totalPoints: 'desc'
+      }
+    })
+
+    // Calculate period-specific points
+    const formattedLeaderboard = leaderboard.map(user => ({
+      id: user.id,
+      name: user.name,
+      totalPoints: user.totalPoints,
+      totalCompletions: user._count.ChoreCompletion,
+      periodPoints: user.pointHistory.reduce((sum, ph) => sum + ph.points, 0)
+    }))
+
+    return res.status(200).json({
+      timeframe,
+      leaderboard: formattedLeaderboard
+    })
+  } catch (error) {
+    console.error('Error fetching leaderboard:', error)
+    return res.status(500).json({ error: 'Failed to fetch leaderboard' })
+  }
+}
+
+export default withAuth(getLeaderboard) 

--- a/api/points/stats.ts
+++ b/api/points/stats.ts
@@ -1,0 +1,69 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
+
+async function getUserStats(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { userId = decodedUser.id } = req.query
+
+  try {
+    const stats = await prisma.$transaction(async (tx) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId as string },
+        select: {
+          id: true,
+          name: true,
+          totalPoints: true,
+          householdId: true
+        }
+      })
+
+      if (!user || user.householdId !== decodedUser.householdId) {
+        throw new Error('User not found or not in same household')
+      }
+
+      const [
+        totalChoresCompleted,
+        pointsByType,
+        currentStreaks
+      ] = await Promise.all([
+        tx.choreCompletion.count({
+          where: { userId: userId as string }
+        }),
+        tx.pointHistory.groupBy({
+          by: ['type'],
+          where: { userId: userId as string },
+          _sum: { points: true }
+        }),
+        tx.chore.findMany({
+          where: {
+            householdId: user.householdId? user.householdId : decodedUser.householdId,
+            currentStreak: { gt: 0 },
+            lastCompletedBy: userId as string
+          },
+          select: {
+            id: true,
+            title: true,
+            currentStreak: true
+          }
+        })
+      ])
+
+      return {
+        user,
+        stats: {
+          totalChoresCompleted,
+          pointsByType,
+          currentStreaks
+        }
+      }
+    })
+
+    return res.status(200).json(stats)
+  } catch (error) {
+    console.error('Error fetching user stats:', error)
+    return res.status(500).json({ error: 'Failed to fetch user statistics' })
+  }
+}
+
+export default withAuth(getUserStats) 

--- a/api/rewards/claim.ts
+++ b/api/rewards/claim.ts
@@ -1,0 +1,116 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { rewardClaimSchema } from '../../lib/validations/rewards'
+import { withAuth } from '../../lib/middleware/auth'    
+
+async function claimReward(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { id } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to claim rewards' })
+  }
+
+  try {
+    // Validate input
+    const validatedData = rewardClaimSchema.parse(req.body)
+
+    // Get the reward and verify access
+    const reward = await prisma.reward.findFirst({
+      where: {
+        id: id as string,
+        householdId: decodedUser.householdId
+      },
+      include: {
+        _count: {
+          select: {
+            claims: {
+              where: {
+                status: 'COMPLETED'
+              }
+            }
+          }
+        }
+      }
+    })
+
+    if (!reward) {
+      return res.status(404).json({ error: 'Reward not found or not accessible' })
+    }
+
+    // Check if reward is claimable
+    if (!reward.isRepeatable && reward.maxClaims && reward._count.claims >= reward.maxClaims) {
+      return res.status(400).json({ error: 'Reward has reached maximum claims' })
+    }
+
+    // Get user's current points
+    const user = await prisma.user.findUnique({
+      where: { id: decodedUser.userId }
+    })
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' })
+    }
+
+    // Check if user has enough points
+    if (user.totalPoints < reward.pointsCost) {
+      return res.status(400).json({ 
+        error: 'Insufficient points',
+        required: reward.pointsCost,
+        current: user.totalPoints
+      })
+    }
+
+    // Create claim and update points in a transaction
+    const result = await prisma.$transaction(async (tx) => {
+      // Create the claim
+      const claim = await tx.rewardClaim.create({
+        data: {
+          userId: decodedUser.userId,
+          rewardId: reward.id,
+          pointsCost: reward.pointsCost,
+          notes: validatedData.notes,
+          status: 'PENDING'
+        }
+      })
+
+      // Create point history
+      const pointHistory = await tx.pointHistory.create({
+        data: {
+          points: -reward.pointsCost,
+          type: 'REWARD_CLAIMED',
+          reason: `Claimed Reward: ${reward.title}`,
+          userId: decodedUser.userId,
+          householdId: decodedUser.householdId,
+          rewardClaimId: claim.id
+        }
+      })
+
+      // Update user's total points
+      const updatedUser = await tx.user.update({
+        where: { id: decodedUser.userId },
+        data: {
+          totalPoints: { decrement: reward.pointsCost }
+        }
+      })
+
+      return { claim, pointHistory, updatedUser }
+    })
+
+    return res.status(200).json({
+      message: 'Reward claimed successfully',
+      claim: {
+        id: result.claim.id,
+        status: result.claim.status,
+        claimedAt: result.claim.claimedAt,
+        pointsCost: result.claim.pointsCost
+      },
+      remainingPoints: result.updatedUser.totalPoints
+    })
+  } catch (error) {
+    console.error('Error claiming reward:', error)
+    return res.status(500).json({ error: 'Failed to claim reward' })
+  }
+}
+
+export default withAuth(claimReward) 

--- a/api/rewards/claims/household.ts
+++ b/api/rewards/claims/household.ts
@@ -1,0 +1,93 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../../lib/prisma'
+import { withAuth } from '../../../lib/middleware/auth'
+import { RewardClaimStatus } from '@prisma/client'
+
+async function getHouseholdClaims(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { page = '1', limit = '10', status, userId } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to view claims' })
+  }
+
+  try {
+    const pageNum = parseInt(page as string)
+    const limitNum = parseInt(limit as string)
+    const skip = (pageNum - 1) * limitNum
+
+    // Build where clause
+    const where = {
+      reward: {
+        householdId: decodedUser.householdId
+      },
+      ...(status ? { status: status as RewardClaimStatus } : {}),
+      ...(userId ? { userId: userId as string } : {})
+    }
+
+    const [claims, total] = await Promise.all([
+      prisma.rewardClaim.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true
+            }
+          },
+          reward: {
+            select: {
+              id: true,
+              title: true,
+              description: true,
+              isDeleted: true
+            }
+          }
+        },
+        orderBy: [
+          { status: 'asc' }, // PENDING first
+          { claimedAt: 'desc' }
+        ],
+        skip,
+        take: limitNum
+      }),
+      prisma.rewardClaim.count({ where })
+    ])
+
+    // Format the response
+    const formattedClaims = claims.map(claim => ({
+      id: claim.id,
+      status: claim.status,
+      claimedAt: claim.claimedAt,
+      completedAt: claim.completedAt,
+      cancelledAt: claim.cancelledAt,
+      pointsCost: claim.pointsCost,
+      notes: claim.notes,
+      user: {
+        id: claim.user.id,
+        name: claim.user.name
+      },
+      reward: {
+        id: claim.reward.id,
+        title: claim.reward.title,
+        description: claim.reward.description,
+        isDeleted: claim.reward.isDeleted
+      }
+    }))
+
+    return res.status(200).json({
+      claims: formattedClaims,
+      pagination: {
+        total,
+        pages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+        perPage: limitNum
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching household claims:', error)
+    return res.status(500).json({ error: 'Failed to fetch claims' })
+  }
+}
+
+export default withAuth(getHouseholdClaims) 

--- a/api/rewards/claims/index.ts
+++ b/api/rewards/claims/index.ts
@@ -1,0 +1,79 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../../lib/prisma'
+import { withAuth } from '../../../lib/middleware/auth'
+import { RewardClaimStatus } from '@prisma/client'
+
+async function getUserClaims(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { page = '1', limit = '10', status } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to view claims' })
+  }
+
+  try {
+    const pageNum = parseInt(page as string)
+    const limitNum = parseInt(limit as string)
+    const skip = (pageNum - 1) * limitNum
+
+    // Build where clause
+    const where = {
+      userId: decodedUser.userId,
+      ...(status ? { status: status as RewardClaimStatus } : {})
+    }
+
+    const [claims, total] = await Promise.all([
+      prisma.rewardClaim.findMany({
+        where,
+        include: {
+          reward: {
+            select: {
+              id: true,
+              title: true,
+              description: true,
+              isDeleted: true
+            }
+          }
+        },
+        orderBy: {
+          claimedAt: 'desc'
+        },
+        skip,
+        take: limitNum
+      }),
+      prisma.rewardClaim.count({ where })
+    ])
+
+    // Format the response
+    const formattedClaims = claims.map(claim => ({
+      id: claim.id,
+      status: claim.status,
+      claimedAt: claim.claimedAt,
+      completedAt: claim.completedAt,
+      cancelledAt: claim.cancelledAt,
+      pointsCost: claim.pointsCost,
+      notes: claim.notes,
+      reward: {
+        id: claim.reward.id,
+        title: claim.reward.title,
+        description: claim.reward.description,
+        isDeleted: claim.reward.isDeleted
+      }
+    }))
+
+    return res.status(200).json({
+      claims: formattedClaims,
+      pagination: {
+        total,
+        pages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+        perPage: limitNum
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching user claims:', error)
+    return res.status(500).json({ error: 'Failed to fetch claims' })
+  }
+}
+
+export default withAuth(getUserClaims) 

--- a/api/rewards/create.ts
+++ b/api/rewards/create.ts
@@ -1,0 +1,56 @@
+// api/rewards/create.ts
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { rewardSchema } from '../../lib/validations/rewards'
+import { withAuth } from '../../lib/middleware/auth'    
+
+async function createReward(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to create rewards' })
+  }
+
+  try {
+    // Validate input
+    const validatedData = rewardSchema.parse(req.body)
+
+    // Create the reward
+    const reward = await prisma.reward.create({
+      data: {
+        ...validatedData,
+        householdId: decodedUser.householdId
+      },
+      include: {
+        _count: {
+          select: {
+            claims: {
+              where: {
+                status: 'COMPLETED'
+              }
+            }
+          }
+        }
+      }
+    })
+
+    // Format the response
+    const formattedReward = {
+      id: reward.id,
+      title: reward.title,
+      description: reward.description,
+      pointsCost: reward.pointsCost,
+      isRepeatable: reward.isRepeatable,
+      maxClaims: reward.maxClaims,
+      totalClaims: reward._count.claims,
+      isClaimable: true // New reward is always claimable
+    }
+
+    return res.status(201).json(formattedReward)
+  } catch (error) {
+    console.error('Error creating reward:', error)
+    return res.status(500).json({ error: 'Failed to create reward' })
+  }
+}
+
+export default withAuth(createReward) 

--- a/api/rewards/delete.ts
+++ b/api/rewards/delete.ts
@@ -1,0 +1,86 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { withAuth } from '../../lib/middleware/auth'
+
+async function deleteReward(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { id } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to delete rewards' })
+  }
+
+  try {
+    // Check if reward exists and belongs to user's household
+    const reward = await prisma.reward.findFirst({
+      where: {
+        id: id as string,
+        householdId: decodedUser.householdId
+      },
+      include: {
+        claims: {
+          where: {
+            status: 'PENDING'
+          }
+        },
+        _count: {
+          select: {
+            claims: {
+              where: {
+                status: 'COMPLETED'
+              }
+            }
+          }
+        }
+      }
+    })
+
+    if (!reward) {
+      return res.status(404).json({ error: 'Reward not found or not accessible' })
+    }
+
+    // Check for active (pending) claims
+    if (reward.claims.length > 0) {
+      return res.status(400).json({ 
+        error: 'Cannot delete reward with pending claims',
+        pendingClaims: reward.claims.length
+      })
+    }
+
+    // If there are completed claims, mark as deleted instead of actually deleting
+    if (reward._count.claims > 0) {
+      const updatedReward = await prisma.reward.update({
+        where: { id: reward.id },
+        data: {
+          isDeleted: true, // You'll need to add this field to the Reward model
+          deletedAt: new Date(),
+          isRepeatable: false, // Prevent new claims
+          maxClaims: 0 // Prevent new claims
+        }
+      })
+
+      return res.status(200).json({
+        message: 'Reward marked as deleted',
+        id: updatedReward.id,
+        note: 'Reward has historical claims and was archived instead of deleted'
+      })
+    }
+
+    // If no historical claims, we can safely delete the reward
+    await prisma.reward.delete({
+      where: {
+        id: reward.id
+      }
+    })
+
+    return res.status(200).json({
+      message: 'Reward deleted successfully',
+      id: reward.id
+    })
+  } catch (error) {
+    console.error('Error deleting reward:', error)
+    return res.status(500).json({ error: 'Failed to delete reward' })
+  }
+}
+
+export default withAuth(deleteReward) 

--- a/api/rewards/get.ts
+++ b/api/rewards/get.ts
@@ -1,0 +1,90 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+
+async function getRewards(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { page = '1', limit = '10' } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to view rewards' })
+  }
+
+  try {
+    const pageNum = parseInt(page as string)
+    const limitNum = parseInt(limit as string)
+    const skip = (pageNum - 1) * limitNum
+
+    const [rewards, total] = await Promise.all([
+      prisma.reward.findMany({
+        where: {
+          householdId: decodedUser.householdId
+        },
+        include: {
+          _count: {
+            select: {
+              claims: {
+                where: {
+                  status: 'COMPLETED'
+                }
+              }
+            }
+          },
+          claims: {
+            where: {
+              userId: decodedUser.userId
+            },
+            orderBy: {
+              claimedAt: 'desc'
+            },
+            take: 1,
+            select: {
+              id: true,
+              status: true,
+              claimedAt: true
+            }
+          }
+        },
+        orderBy: {
+          createdAt: 'desc'
+        },
+        skip,
+        take: limitNum
+      }),
+      prisma.reward.count({
+        where: {
+          householdId: decodedUser.householdId
+        }
+      })
+    ])
+
+    // Format the response
+    const formattedRewards = rewards.map(reward => ({
+      id: reward.id,
+      title: reward.title,
+      description: reward.description,
+      pointsCost: reward.pointsCost,
+      isRepeatable: reward.isRepeatable,
+      maxClaims: reward.maxClaims,
+      totalClaims: reward._count.claims,
+      isClaimable: reward.isRepeatable || (
+        reward.maxClaims ? reward._count.claims < reward.maxClaims : true
+      ),
+      lastClaim: reward.claims[0] || null
+    }))
+
+    return res.status(200).json({
+      rewards: formattedRewards,
+      pagination: {
+        total,
+        pages: Math.ceil(total / limitNum),
+        currentPage: pageNum,
+        perPage: limitNum
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching rewards:', error)
+    return res.status(500).json({ error: 'Failed to fetch rewards' })
+  }
+}
+
+export default getRewards 

--- a/api/rewards/index.ts
+++ b/api/rewards/index.ts
@@ -1,0 +1,31 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import { withAuth } from '../../lib/middleware/auth'
+import getRewards from './get'
+import createReward from './create'
+import claimReward from './claim'
+import updateClaim from './updateClaim'
+
+async function handler(req: VercelRequest, res: VercelResponse) {
+  const { action, id } = req.query
+
+  // Handle specific actions
+  if (action === 'claim' && id) {
+    return claimReward(req, res)
+  }
+
+  if (req.method === 'PATCH' && req.url?.includes('/claims/')) {
+    return updateClaim(req, res)
+  }
+
+  // Handle standard CRUD operations
+  switch (req.method) {
+    case 'GET':
+      return getRewards(req, res)
+    case 'POST':
+      return createReward(req, res)
+    default:
+      return res.status(405).json({ error: 'Method not allowed' })
+  }
+}
+
+export default withAuth(handler) 

--- a/api/rewards/updateClaim.ts
+++ b/api/rewards/updateClaim.ts
@@ -1,0 +1,107 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import prisma from '../../lib/prisma'
+import { updateClaimStatusSchema } from '../../lib/validations/rewards'
+
+async function updateClaim(req: VercelRequest, res: VercelResponse) {
+  const { decodedUser } = req.body
+  const { id } = req.query
+
+  if (!decodedUser.householdId) {
+    return res.status(403).json({ error: 'User must be part of a household to manage reward claims' })
+  }
+
+  try {
+    // Validate input
+    const validatedData = updateClaimStatusSchema.parse(req.body)
+
+    // Get the claim and verify access
+    const claim = await prisma.rewardClaim.findFirst({
+      where: {
+        id: id as string,
+        reward: {
+          householdId: decodedUser.householdId
+        }
+      },
+      include: {
+        reward: true,
+        user: true
+      }
+    })
+
+    if (!claim) {
+      return res.status(404).json({ error: 'Claim not found or not accessible' })
+    }
+
+    if (claim.status !== 'PENDING') {
+      return res.status(400).json({ error: 'Only pending claims can be updated' })
+    }
+
+    // Update claim in a transaction
+    const result = await prisma.$transaction(async (tx) => {
+      const updatedClaim = await tx.rewardClaim.update({
+        where: { id: claim.id },
+        data: {
+          status: validatedData.status,
+          notes: validatedData.notes,
+          completedAt: validatedData.status === 'COMPLETED' ? new Date() : null,
+          cancelledAt: validatedData.status === 'CANCELLED' ? new Date() : null
+        },
+        include: {
+          reward: true,
+          user: true
+        }
+      })
+
+      // If cancelled, refund points
+      if (validatedData.status === 'CANCELLED') {
+        // Create refund point history
+        await tx.pointHistory.create({
+          data: {
+            points: claim.pointsCost, // Positive for refund
+            type: 'REWARD_CLAIMED',
+            reason: `Refund for cancelled reward: ${claim.reward.title}`,
+            userId: claim.userId,
+            householdId: decodedUser.householdId,
+            rewardClaimId: claim.id
+          }
+        })
+
+        // Update user's total points
+        await tx.user.update({
+          where: { id: claim.userId },
+          data: {
+            totalPoints: { increment: claim.pointsCost }
+          }
+        })
+      }
+
+      return updatedClaim
+    })
+
+    return res.status(200).json({
+      message: `Claim ${validatedData.status.toLowerCase()} successfully`,
+      claim: {
+        id: result.id,
+        status: result.status,
+        claimedAt: result.claimedAt,
+        completedAt: result.completedAt,
+        cancelledAt: result.cancelledAt,
+        pointsCost: result.pointsCost,
+        notes: result.notes,
+        user: {
+          id: result.user.id,
+          name: result.user.name
+        },
+        reward: {
+          id: result.reward.id,
+          title: result.reward.title
+        }
+      }
+    })
+  } catch (error) {
+    console.error('Error updating claim:', error)
+    return res.status(500).json({ error: 'Failed to update claim' })
+  }
+}
+
+export default updateClaim 

--- a/lib/validations/rewards.ts
+++ b/lib/validations/rewards.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+import { RewardClaimStatus } from '@prisma/client'
+
+// Schema for creating/updating rewards
+export const rewardSchema = z.object({
+  title: z.string()
+    .min(1, { message: 'Title is required' })
+    .max(100, { message: 'Title cannot exceed 100 characters' }),
+  description: z.string()
+    .max(500, { message: 'Description cannot exceed 500 characters' })
+    .optional(),
+  pointsCost: z.number()
+    .int({ message: 'Points cost must be a whole number' })
+    .positive({ message: 'Points cost must be positive' }),
+  isRepeatable: z.boolean().default(true),
+  maxClaims: z.number()
+    .int({ message: 'Max claims must be a whole number' })
+    .positive({ message: 'Max claims must be positive' })
+    .optional()
+})
+
+// Schema for claiming a reward
+export const rewardClaimSchema = z.object({
+  notes: z.string()
+    .max(500, { message: 'Notes cannot exceed 500 characters' })
+    .optional()
+})
+
+// Schema for updating a claim status
+export const updateClaimStatusSchema = z.object({
+  status: z.enum([RewardClaimStatus.COMPLETED, RewardClaimStatus.CANCELLED]),
+  notes: z.string()
+    .max(500, { message: 'Notes cannot exceed 500 characters' })
+    .optional()
+}) 

--- a/prisma/migrations/20250402172756_add_soft_delete_to_rewards/migration.sql
+++ b/prisma/migrations/20250402172756_add_soft_delete_to_rewards/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Reward" ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,6 +189,8 @@ model Reward {
   maxClaims    Int? // null means unlimited claims
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  isDeleted    Boolean  @default(false)
+  deletedAt    DateTime?
 
   // Relationships
   householdId String


### PR DESCRIPTION
Implements a new leaderboard endpoint to fetch user rankings based on  points, filtered by timeframe. Adds authentication to existing endpoints  for point history and chores. Introduces soft delete columns to the  rewards table for better data management. Enhances the update claim  endpoint validate input and manage claim statuses effectively.